### PR TITLE
added easycrystallography

### DIFF
--- a/easycrystallography/index.html
+++ b/easycrystallography/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Links for easyCrystallography (alpha)</title>
+</head>
+<body>
+<h1>Links for easyCrystallography</h1>
+<a href="https://github.com/easyScience/easyCrystallography/releases/download/v0.2.3a0/easycrystallography-0.2.3a0-py3-none-any.whl" data-requires-python="&gt=3.7,&lt4.0">easycrystallography-0.2.3a0-py3-none-any</a><br/>
+<a href="https://github.com/easyScience/easyCrystallography/releases/download/v0.2.2a0/easycrystallography-0.2.2a0-py3-none-any.whl" data-requires-python="&gt=3.7,&lt4.0">easycrystallography-0.2.2a0-py3-none-any</a><br/>
+<a href="https://github.com/easyScience/easyCrystallography/releases/download/v0.2.1a0/easycrystallography-0.2.1a0-py3-none-any.whl" data-requires-python="&gt=3.7,&lt4.0">easycrystallography-0.2.1a0-py3-none-any</a><br/>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
 </section>
 <div class="package" >
     <a href="easysciencecore/">easyCore</a><br/>
+    <a href="easycrystallography/">easyCrystallography</a><br/>
     <a href="easydiffraction/">easyDiffraction</a><br/>
     <a href="cfml/">CFML</a><br/>
     <a href="gsasii/">GSASII</a><br/>


### PR DESCRIPTION
seems that the build process of easycrystallography does update the local pypi page. Originally, it was a copy of the easyCore link, so every `develop` build in easyCrystallography would overwrite easyCore repo with ECryst links

This PR fixes the issue buy adding separate easycrystallography directory